### PR TITLE
Update the location of the BMI sample

### DIFF
--- a/_docs/cn/load-balance.md
+++ b/_docs/cn/load-balance.md
@@ -32,7 +32,7 @@ or
 mvn spring-boot:run -Dspring-boot.run.jvmArguments="-Dcse.rest.address=0.0.0.0:7778"
 ```
 
-为了便于区分不同的运行实例，在体质指数计算器的实现中新增了返回实例ID和运行时间的接口，详情可查看[体质指数计算器的完整实现代码](https://github.com/apache/servicecomb-java-chassis/tree/master/samples/bmi/calculator)。而为了避免端口冲突，新的实例在另一个端口上运行。
+为了便于区分不同的运行实例，在体质指数计算器的实现中新增了返回实例ID和运行时间的接口，详情可查看[体质指数计算器的完整实现代码](https://github.com/apache/servicecomb-samples/tree/1.3.0/java-chassis-samples/bmi/calculator)。而为了避免端口冲突，新的实例在另一个端口上运行。
 
 此时点击 *Submit* 按钮就可以看到如下两个界面中的实例ID交替出现。
 

--- a/_docs/cn/quick-start-bmi.md
+++ b/_docs/cn/quick-start-bmi.md
@@ -41,7 +41,7 @@ last_modified_at: 2017-09-04T10:01:43-04:00
 ```
 **注意**: `java-chassis-dependencies` 这个依赖是以pom的形式导入来统一项目中的依赖项的版本管理。
 
-下面将对这两个微服务的实现进行介绍，其代码已托管于[github](https://github.com/apache/servicecomb-java-chassis/tree/master/samples/bmi)上。
+下面将对这两个微服务的实现进行介绍，其代码已托管于[github](https://github.com/apache/servicecomb-samples/tree/1.3.0/java-chassis-samples/bmi)上。
 ### 体质指数计算器实现
 体质指数计算器提供运算服务，其实现分为三部分：
 

--- a/_docs/load-balance.md
+++ b/_docs/load-balance.md
@@ -31,7 +31,7 @@ or
 mvn spring-boot:run -Dspring-boot.run.jvmArguments="-Dcse.rest.address=0.0.0.0:7778"
 ```
 
-To better distinguish different running instances, we added a new interface that returns instance id in the implementation of BMI calculator, details can refer to [the implementation of BMI calculator](https://github.com/apache/servicecomb-java-chassis/tree/master/samples/bmi/calculator). Besides, a different service port is needed to avoid port conflict.
+To better distinguish different running instances, we added a new interface that returns instance id in the implementation of BMI calculator, details can refer to [the implementation of BMI calculator](https://github.com/apache/servicecomb-samples/tree/1.3.0/java-chassis-samples/bmi/calculator). Besides, a different service port is needed to avoid port conflict.
 
 Now you can see the instance id in the following figures shows up alternately by clicking the *Submit* button.
 

--- a/_docs/quick-start-bmi.md
+++ b/_docs/quick-start-bmi.md
@@ -41,7 +41,7 @@ Before we start, we need to add some common dependencies in the parent project o
 ```
 **Notice**: The `java-chassis-dependencies` is imported as pom to unify version management of dependencies.
 
-Now we will introduce the detailed implementation of these two microservices. The full code is on [github](https://github.com/apache/servicecomb-java-chassis/tree/master/samples/bmi).
+Now we will introduce the detailed implementation of these two microservices. The full code is on [github](https://github.com/apache/servicecomb-samples/tree/1.3.0/java-chassis-samples/bmi).
 ### Implementation of calculator
 The calculator service provides capability of calculating BMI. It contains three parts:
 


### PR DESCRIPTION
The sample module of [ServiceComb-Java-Chassis](https://github.com/apache/servicecomb-java-chassis) has been moved to the [ServiceComb-Samples](https://github.com/apache/servicecomb-samples). And the BMI sample only exists on [1.3.0](https://github.com/apache/servicecomb-samples/tree/1.3.0) branch.